### PR TITLE
New criterion for selection before-and-after estimator bandwidth

### DIFF
--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -292,7 +292,7 @@ labels <- labels[1:(length(labels)-1)]
 binvalue_raw <- cut(plot_table$abs_diff, breaks = bins, labels = labels,
                 include.lowest = FALSE, right = TRUE)
 binvalue <- addNA(binvalue_raw) #~ ensure <NA> is a factor as NA
-levels(binvalue) <- c(levels(binvalue_raw), "=0") #~ replace level NA with "= 0"
+levels(binvalue) <- c(levels(binvalue_raw), "= 0") #~ replace level NA with "= 0"
 binvalue <- factor(binvalue, #~ reorganize levels so that "= 0" comes first
                    levels(binvalue)[c(length(levels(binvalue)),
                                       1:(length(levels(binvalue))-1))])

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -283,3 +283,45 @@ ggplot() +
 
 ggsave(paste("fig_newcriterion", suffix,  "total_scatter_clean", suffix, "OK.jpg", sep = ""), path = img_path,
        width = default_width, height = default_height + 2, units = "in")
+
+# Binning ------
+binwidth <- 10000
+bins <- seq(0, max(final_support) + binwidth, by = binwidth)
+labels <- paste(">", bins)
+labels <- labels[1:(length(labels)-1)]
+binvalue_raw <- cut(plot_table$abs_diff, breaks = bins, labels = labels,
+                include.lowest = FALSE, right = TRUE)
+binvalue <- addNA(binvalue_raw) #~ ensure <NA> is a factor as NA
+levels(binvalue) <- c(levels(binvalue_raw), "=0") #~ replace level NA with "= 0"
+binvalue <- factor(binvalue, #~ reorganize levels so that "= 0" comes first
+                   levels(binvalue)[c(length(levels(binvalue)),
+                                      1:(length(levels(binvalue))-1))])
+plot_table_bins <- cbind(plot_table, binvalue) %>%
+  dplyr::group_by(binvalue) %>%
+  dplyr::summarise(sum = sum(gamma))
+
+ggplot() +
+  geom_bar(data = plot_table_bins, stat = "identity",
+           aes(x = binvalue, y = sum)) +
+  theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5),
+            xangle = 90) +
+  xlab("binned absolute difference") +
+  ylab("total average mass transferred")
+
+ggsave(paste("fig_newcriterion", suffix,  "total_bin", suffix, "OK.jpg", sep = ""), path = img_path,
+       width = default_width, height = default_height + 2, units = "in")
+
+#~ cleaner plot
+plot_table_bins_cleaned <- plot_table_bins %>%
+  dplyr::filter(sum != 0)
+
+ggplot() +
+  geom_bar(data = plot_table_bins_cleaned, stat = "identity",
+           aes(x = binvalue, y = sum)) +
+  theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5),
+            xangle = 90) +
+  xlab("binned absolute difference") +
+  ylab("total average mass transferred")
+
+ggsave(paste("fig_newcriterion", suffix,  "total_bin_clean", suffix, "OK.jpg", sep = ""), path = img_path,
+       width = default_width, height = default_height + 2, units = "in")

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -30,7 +30,7 @@ linetype1 <- "dashed" # secondary line type
 linetype2 <- "dotted" # tertiary line type
 linetype3 <- "twodash"
 linetype4 <- "longdash"
-img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct23", paste(version, temp, sep = "-"), sep = "/")
+img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct25", paste(version, temp, sep = "-"), sep = "/")
 suffix <- "_"
 default_width <- 7
 default_height <- 3
@@ -135,17 +135,20 @@ plot_table <- data.frame(bandwidth = bandwidth_seq, mean = mean_results, sd = sd
                                         TRUE ~ name))
 
 ggplot(plot_table) +
-  geom_line(aes(x = bandwidth, y = value, color = name)) +
-  # scale_color_manual(values = get_color_palette(5, grayscale),
-                     # labels = c("99%ile", "95%ile", "90%ile", "mean", "st. dev."),
-                     # name = "") +
-  # scale_linetype_manual(values = c(linetype0, linetype1, linetype2, linetype3, linetype4),
-                        # labels = c("99%ile", "95%ile", "90%ile", "mean", "st. dev."),
-                        # name = "") +
+  geom_line(aes(x = bandwidth, y = value, 
+                color = factor(name, levels = c("99%ile", "95%ile", "90%ile", "mean", "sd")))) +
+  scale_color_manual(values = get_color_palette(5, grayscale),
+                     labels = c("99%ile", "95%ile", "90%ile", "mean", "st. dev."),
+                     name = "") +
+  scale_linetype_manual(values = c(linetype0, linetype1, linetype2, linetype3, linetype4),
+                        labels = c("99%ile", "95%ile", "90%ile", "mean", "st. dev."),
+                        name = "") +
+  scale_y_continuous(breaks = seq(0, max(plot_table$value), 2000), 
+                     labels = seq(0, max(plot_table$value), 2000)) +
   scale_x_continuous(breaks = seq(0, 20000, 2000), labels = seq(0, 20000, 2000)) +
   theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5),
-            legend.direction = "horizontal",
-            legend.position = c(0.65, 0.3))
+            legend.direction = "vertical",
+            legend.position = c(0.85, 0.8))
 
 ggsave(paste("fig_newcriterion", suffix, "OK.jpg", sep = ""), path = img_path,
        width = default_width, height = default_height+1, units = "in")

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -158,12 +158,13 @@ ggsave(paste("fig_newcriterion", suffix,  "perc", suffix, "OK.jpg", sep = ""), p
        width = default_width, height = default_height+1, units = "in")
 
 if (length(unique(support_raw)) == 1) {
-  gamma_list <- lapply(gamma_raw, c)
-  gamma_mat <- matrix(unlist(gamma_raw), ncol = length(gamma_list[[1]]), byrow = T)
-  gamma_vec <- apply(gamma_mat, 2, mean)
-  gamma_dt <- data.frame(gamma_vec = gamma_vec)
-  gamma_sd <- apply(gamma_mat, 2, sd)
-  gamma_max <- apply(gamma_mat, 2, max)
+  #~ get support of gamma matrix
+  final_support <- support_raw[[1]]
+  #~ get mean of each entry in gamma matrix across all 500 simulations
+  #~ save the result as a matrix and a vector
+  gamma_mean_mat <- apply(simplify2array(gamma_raw), c(1, 2), mean)
+  gamma_mean_vec <- c(gamma_mean_mat)
+  gamma_dt <- data.frame(gamma_vec = gamma_mean_vec)
 }
 
 ggplot(gamma_dt) +

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -109,10 +109,16 @@ for (sim in seq_len(numsims)) {
 
   gamma <- tilde_gamma - hat_gamma
 
+  # temp_old <- 0
   for (bw in seq_along(bandwidth_seq)){
     bandwidth <- bandwidth_seq[bw]
     cost <- build_costmatrix(support, bandwidth = bandwidth)
     results[sim, bw] <- sum(cost * gamma)
+    # temp_new <- sum(cost * gamma == 0)
+    # if (temp_new < temp_old) {
+    #   print(c(sim, bw))
+    # }
+    # temp_old <- temp_new
   }
 
 }

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -30,7 +30,7 @@ linetype1 <- "dashed" # secondary line type
 linetype2 <- "dotted" # tertiary line type
 linetype3 <- "twodash"
 linetype4 <- "longdash"
-img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct26", paste(version, temp, sep = "-"), sep = "/")
+img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct27", paste(version, temp, sep = "-"), sep = "/")
 suffix <- "_"
 default_width <- 7
 default_height <- 3
@@ -168,6 +168,8 @@ if (length(unique(support_raw)) == 1) {
   gamma_mat <- matrix(unlist(gamma_raw), ncol = length(gamma_list[[1]]), byrow = T)
   gamma_vec <- apply(gamma_mat, 2, mean)
   gamma_dt <- data.frame(gamma_vec = gamma_vec)
+  gamma_sd <- apply(gamma_mat, 2, sd)
+  gamma_max <- apply(gamma_mat, 2, max)
 }
 
 ggplot(gamma_dt) +

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -30,13 +30,13 @@ linetype1 <- "dashed" # secondary line type
 linetype2 <- "dotted" # tertiary line type
 linetype3 <- "twodash"
 linetype4 <- "longdash"
-img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct25", paste(version, temp, sep = "-"), sep = "/")
+img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Oct26", paste(version, temp, sep = "-"), sep = "/")
 suffix <- "_"
 default_width <- 7
 default_height <- 3
 
 epsilon <- 0.1
-bandwidth_seq <- seq(0, 20000, 1000)
+bandwidth_seq <- seq(0, 40000, 1000)
 numsims <- 500
 results_raw <- matrix(NA_real_, nrow = numsims, ncol = length(bandwidth_seq))
 
@@ -148,8 +148,9 @@ ggplot(plot_table) +
   # scale_y_continuous(breaks = seq(0, max(plot_table$value), 2000),
                      # labels = seq(0, max(plot_table$value), 2000)) +
   scale_y_continuous(breaks = seq(0, 8, 0.5), labels = seq(0, 8, 0.5)) +
-  scale_x_continuous(breaks = seq(0, 20000, 2000), labels = seq(0, 20000, 2000)) +
+  scale_x_continuous(breaks = seq(0, 40000, 4000), labels = seq(0, 40000, 4000)) +
   ylab("Percentage") +
+  xlab("d") +
   theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5),
             legend.direction = "vertical",
             legend.position = c(0.85, 0.8))
@@ -162,7 +163,8 @@ ggplot(gamma_vec) +
   geom_histogram(aes(x = gamma_vec, y = stat(count)/sum(stat(count))), binwidth = 10) +
   bmp_plot(data = gamma_vec,
            xlab = "Absolute Difference in Transport Maps",
-           xtype = "continuous", xbreaks = seq(0, 300, 20), xlabels = seq(0, 300, 20),
+           ylab = "Density",
+           xtype = "continuous", xbreaks = seq(0, 600, 30), xlabels = seq(0, 600, 30),
            sizefont = (fontsize - 8),
            axissizefont = (fontsizeaxis - 5))
 

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -1,0 +1,88 @@
+### Header ---------------------------
+###
+### Title: new-criterion.R
+###
+### Description: Implement new criterion for choosing bandwidth for before-and-after estimator
+###
+### Author: Omkar A. Katta
+###
+### Notes: See email exchange with Guillaume (Oct 21, 23)
+###
+
+### Preliminaries ---------------------------
+devtools::load_all()
+
+source(here::here("data-raw", "prepare_data.R"))
+load(here::here(".hidden/Beijing_cleaned.RData"))
+Beijing <- Beijing_cleaned
+
+common_support <- prep_data(Beijing, prep = "support", lowerdate = "2010-01-01", upperdate = "2013-01-01")
+pre <- prep_data(Beijing, prep = "pmf",
+                 support = common_support,
+                 lowerdate = "2010-01-01", upperdate = "2011-01-01")
+post <- prep_data(Beijing, prep = "pmf",
+                  support = common_support,
+                  lowerdate = "2012-01-01", upperdate = "2013-01-01")
+pre_tilde <- data.frame(MSRP = pre$MSRP, count = rmultinom(1, sum(pre$count), pre$count))
+post_tilde <- data.frame(MSRP = post$MSRP, count = rmultinom(1, sum(post$count), post$count))
+
+# bandwidth_seq <- seq(0, 40000, 1000)
+bw <- 0
+epsilon <- 0.1
+
+Lpcost <- function(min_pre_support, min_post_support, p) {
+  costm <- matrix(NA_real_, nrow = length(min_pre_support), ncol = length(min_post_support))
+  for (i in seq_along(min_pre_support)) {
+      costm[i, ] <- abs(min_pre_support[i] - min_post_support)^p
+  }
+  costm
+}
+
+common_cost <- Lpcost(common_support, common_support, p = epsilon)
+hat_OT <- transport(
+  as.numeric(sum(post$count) / sum(pre$count) * pre$count),
+  as.numeric(post$count),
+  common_cost
+)
+tilde_OT <- transport(
+  as.numeric(sum(post_tilde$count) / sum(pre_tilde$count) * pre_tilde$count),
+  as.numeric(post_tilde$count),
+  common_cost
+)
+
+pre_support <- unique(pre$MSRP[pre$count != 0 & !is.na(pre$MSRP)])
+post_support <- unique(post$MSRP[post$count != 0 & !is.na(post$MSRP)])
+pre_tilde_support <- unique(pre_tilde$MSRP[pre_tilde$count != 0 & !is.na(pre_tilde$MSRP)])
+post_tilde_support <- unique(post_tilde$MSRP[post_tilde$count != 0 & !is.na(post_tilde$MSRP)])
+
+hat_OT_revised <- hat_OT %>% 
+  dplyr::rename(hat_mass = mass) %>% 
+  dplyr::mutate(from = pre_support[from]) %>%
+  dplyr::mutate(to = post_support[to])
+tilde_OT_revised <- tilde_OT %>% 
+  dplyr::rename(tilde_mass = mass) %>% 
+  dplyr::mutate(from = pre_tilde_support[from]) %>%
+  dplyr::mutate(to = post_tilde_support[to])
+
+OT_combine <- dplyr::full_join(hat_OT_revised, tilde_OT_revised, by = c("from", "to"))
+support <- unique(sort(c(OT_combine$from, OT_combine$to)))
+
+OT_final <- OT_combine %>%
+  dplyr::rowwise() %>%
+  dplyr::mutate(from = which(support == from)) %>% 
+  dplyr::mutate(to = which(support == to)) %>%
+  dplyr::ungroup()
+
+hat_gamma <- matrix(0, nrow = length(support), ncol = length(support))
+tilde_gamma <- matrix(0, nrow = length(support), ncol = length(support))
+for (i in seq_len(nrow(OT_final))) {
+  temprow <- OT_final[i, ]
+  hat_gamma[as.numeric(temprow["from"]), as.numeric(temprow["to"])] <- as.numeric(temprow["hat_mass"])
+  tilde_gamma[as.numeric(temprow["from"]), as.numeric(temprow["to"])] <- as.numeric(temprow["tilde_mass"])
+}
+hat_gamma[is.na(hat_gamma)] <- 0
+tilde_gamma[is.na(tilde_gamma)] <- 0
+
+gamma <- tilde_gamma - hat_gamma
+cost <- build_costmatrix(support, bandwidth = bw)
+OT <- sum(cost * gamma)

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -156,3 +156,15 @@ ggplot(plot_table) +
 
 ggsave(paste("fig_newcriterion", suffix,  "perc", suffix, "OK.jpg", sep = ""), path = img_path,
        width = default_width, height = default_height+1, units = "in")
+
+gamma_vec <- data.frame(gamma_vec = c(gamma))
+ggplot(gamma_vec) +
+  geom_histogram(aes(x = gamma_vec, y = stat(count)/sum(stat(count))), binwidth = 10) +
+  bmp_plot(data = gamma_vec,
+           xlab = "Absolute Difference in Transport Maps",
+           xtype = "continuous", xbreaks = seq(0, 300, 20), xlabels = seq(0, 300, 20),
+           sizefont = (fontsize - 8),
+           axissizefont = (fontsizeaxis - 5))
+
+ggsave(paste("fig_newcriterion", suffix,  "gamma", suffix, "OK.jpg", sep = ""), path = img_path,
+       width = default_width, height = default_height, units = "in")

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -115,16 +115,10 @@ for (sim in seq_len(numsims)) {
   gamma_raw[[sim]] <- gamma
   support_raw[[sim]] <- support
 
-  # temp_old <- 0
-  for (bw in seq_along(bandwidth_seq)){
+  for (bw in seq_along(bandwidth_seq)) {
     bandwidth <- bandwidth_seq[bw]
     cost <- build_costmatrix(support, bandwidth = bandwidth)
     results_raw[sim, bw] <- sum(cost * gamma)
-    # temp_new <- sum(cost * gamma == 0)
-    # if (temp_new < temp_old) {
-    #   print(c(sim, bw))
-    # }
-    # temp_old <- temp_new
   }
 
 }

--- a/data-raw/new-criterion.R
+++ b/data-raw/new-criterion.R
@@ -107,7 +107,7 @@ for (sim in seq_len(numsims)) {
   hat_gamma[is.na(hat_gamma)] <- 0
   tilde_gamma[is.na(tilde_gamma)] <- 0
 
-  gamma <- tilde_gamma - hat_gamma
+  gamma <- abs(tilde_gamma - hat_gamma)
 
   # temp_old <- 0
   for (bw in seq_along(bandwidth_seq)){

--- a/data-raw/reproduce_results.R
+++ b/data-raw/reproduce_results.R
@@ -509,8 +509,127 @@ if (show_fig | show_fig6){
   message(paste("Figure ", fignum, " is complete.", sep = ""))
 }
 
-### Figure 6 - B1011 ---------------------------
+### Figure 6 - Nov2 ---------------------------
 fignum <- "6_B1011" # this is what we want :)
+if (show_fig | show_fig6) {
+  set.seed(11 + seedplus)
+  support <- prep_data(data = Beijing, prep = "support")
+
+  pre <- prep_data(Beijing, prep = "pmf",
+                   support = support,
+                   lowerdate = "2010-01-01", upperdate = "2011-01-01")
+  post <- prep_data(Beijing, prep = "pmf",
+                    support = support,
+                    lowerdate = "2011-01-01", upperdate = "2012-01-01")
+  bandwidth_seq = seq(0, 100000, 1000)
+
+  real <- diftrans(pre, post, bandwidth_seq = bandwidth_seq, conservative = F)
+
+  numsims <- 500
+  placebo_results <- matrix(NA, nrow = numsims, ncol = length(bandwidth_seq))
+  for (i in seq_len(numsims)) {
+    print(paste("Simulation Number", i, "out of", numsims, sep = " "))
+    # draw n_B,2010 samples from Beijing, 2010
+    synth_pre1 <- data.frame(MSRP = pre$MSRP,
+                             count = rmultinom(1, sum(pre$count), pre$count))
+    # draw n_B,2011 samples from Beijing, 2010
+    synth_pre2 <- data.frame(MSRP = pre$MSRP,
+                             count = rmultinom(1, sum(post$count), pre$count))
+    placebo <- diftrans(synth_pre1, synth_pre2, 
+                        bandwidth_seq = bandwidth_seq, conservative = F)
+    placebo_results[i, ] <- placebo$main
+  }
+
+  placebo_mean <- apply(placebo_results, 2, mean)*100
+  placebo_sd <- apply(placebo_results, 2, sd)*100
+  probs <- c(0.90, 0.95, 0.99)
+  placebo_quantiles <- apply(placebo_results, 2, quantile, prob = probs)*100
+
+  plot_mat <- do.call(rbind, list(placebo_mean, placebo_sd, placebo_quantiles))
+  rownames(plot_mat) <- c("mean", "sd", paste("quantile", probs, sep = ""))
+  plot_table <- t(plot_mat) %>%
+    as.data.frame() %>%
+    mutate(bandwidth = bandwidth_seq,
+           real = real$main*100) %>%
+    select(bandwidth, real, everything())
+
+  # close to mean placebo = 0.05%
+  lower <- 0.04
+  upper <- 0.06
+  valid <- plot_table$bandwidth[plot_table$mean < upper & plot_table$mean > lower]
+
+  # knitr table
+  d_table <- plot_table %>%
+    filter(bandwidth %in% c(valid,
+                            4000, 5000, 6000, 7000, 8000, 9000, 10000,
+                            15000, 20000, 25000, 30000, 35000, 40000, 45000,
+                            50000, 70000, 90000))
+  knitr::kable(d_table, format = "latex", booktabs = T, linesep = "")
+
+  # plot real and mean - fig6
+  fig6_plot <- ggplot(data = plot_table, aes(x = bandwidth)) +
+    geom_line(aes(y = real, color = "0", linetype = "0")) +
+    #~ geom_line(aes(y = quantile0.99, color = "1", linetype = "1")) +
+    #~ geom_line(aes(y = quantile0.95, color = "2", linetype = "2")) +
+    #~ geom_line(aes(y = quantile0.9, color = "3", linetype = "3")) +
+    geom_line(aes(y = mean, color = "5", linetype = "5")) +
+    scale_color_manual(values = get_color_palette(2, grayscale),
+                       labels = c("real", "placebo"),
+                       name = "") +
+    scale_linetype_manual(values = c(linetype0, linetype1, linetype2),
+                          labels = c("real", "placebo"),
+                          name = "") +
+    bmp_vline(xint = 25000) +
+    xlab("d") +
+    ylab("Transport Cost (%)") +
+    theme_bmp(sizefont = (fontsize - 8),
+              axissizefont = (fontsizeaxis - 5)) +
+    scale_x_continuous(breaks = seq(0, 100000, 10000))
+
+  ggsave()
+
+  # simulation results (no real cost)
+  fig6_plot2 <- ggplot(data = plot_table, aes(x = bandwidth)) +
+    geom_line(aes(y = quantile0.99, color = "1", linetype = "1")) +
+    geom_line(aes(y = quantile0.95, color = "2", linetype = "2")) +
+    geom_line(aes(y = quantile0.9, color = "3", linetype = "3")) +
+    geom_line(aes(y = mean, color = "5", linetype = "5")) +
+    geom_line(aes(y = sd, color = "6", linetype = "6")) +
+    scale_color_manual(values = get_color_palette(5, grayscale),
+                       labels = c("99%ile", "95%ile", "90%ile", "mean", "sd"),
+                       name = "") +
+    scale_linetype_manual(values = c(linetype0, linetype1, linetype2, linetype3, linetype4),
+                          labels = c("99%ile", "95%ile", "90%ile", "mean", "sd"),
+                          name = "") +
+    bmp_vline(xint = 25000) +
+    xlab("d") +
+    ylab("Transport Cost (%)") +
+    theme_bmp(sizefont = (fontsize - 8),
+              axissizefont = (fontsizeaxis - 5),
+              legend.position = c(0.8, 0.7)) +
+    scale_y_continuous(breaks = seq(0, 1.6, 0.1)) +
+    scale_x_continuous(breaks = seq(0, 100000, 10000))
+
+  if (save_fig | save_fig6){
+    ggsave(paste("fig", fignum, suffix, "OK.jpg", sep = ""),
+           path = img_path, fig6_plot,
+           width = default_width, height = default_height, units = "in")
+    message(paste("fig", fignum, " is saved in ", img_path, " as fig", 
+                  fignum, suffix, "OK.jpg", sep = ""))
+    ggsave(paste("fig", fignum, suffix,"zoomed", suffix, "OK.jpg", sep = ""),
+           path = img_path, fig6_plot2,
+           width = default_width, height = default_height, units = "in")
+    message(paste("fig", fignum, "_zoomed", " is saved in ", img_path, " as fig", 
+                  fignum, suffix, "OK.jpg", sep = ""))
+  }
+
+  message(paste("Figure ", fignum, " is complete.", sep = ""))
+
+
+}
+
+### Figure 6 - B1011 ---------------------------
+fignum <- "6_B1011" 
 if (show_fig | show_fig6){
   set.seed(11 + seedplus)
   support <- prep_data(data = Beijing, prep = "support")

--- a/data-raw/reproduce_results.R
+++ b/data-raw/reproduce_results.R
@@ -586,8 +586,6 @@ if (show_fig | show_fig6) {
               axissizefont = (fontsizeaxis - 5)) +
     scale_x_continuous(breaks = seq(0, 100000, 10000))
 
-  ggsave()
-
   # simulation results (no real cost)
   fig6_plot2 <- ggplot(data = plot_table, aes(x = bandwidth)) +
     geom_line(aes(y = quantile0.99, color = "1", linetype = "1")) +

--- a/data-raw/reproduce_results.R
+++ b/data-raw/reproduce_results.R
@@ -509,7 +509,7 @@ if (show_fig | show_fig6){
   message(paste("Figure ", fignum, " is complete.", sep = ""))
 }
 
-### Figure 6 - Nov2 ---------------------------
+### Figure 6 - Nov02 ---------------------------
 fignum <- "6_B1011" # this is what we want :)
 if (show_fig | show_fig6) {
   set.seed(11 + seedplus)
@@ -521,7 +521,7 @@ if (show_fig | show_fig6) {
   post <- prep_data(Beijing, prep = "pmf",
                     support = support,
                     lowerdate = "2011-01-01", upperdate = "2012-01-01")
-  bandwidth_seq = seq(0, 100000, 1000)
+  bandwidth_seq <- seq(0, 100000, 1000)
 
   real <- diftrans(pre, post, bandwidth_seq = bandwidth_seq, conservative = F)
 
@@ -535,22 +535,22 @@ if (show_fig | show_fig6) {
     # draw n_B,2011 samples from Beijing, 2010
     synth_pre2 <- data.frame(MSRP = pre$MSRP,
                              count = rmultinom(1, sum(post$count), pre$count))
-    placebo <- diftrans(synth_pre1, synth_pre2, 
+    placebo <- diftrans(synth_pre1, synth_pre2,
                         bandwidth_seq = bandwidth_seq, conservative = F)
     placebo_results[i, ] <- placebo$main
   }
 
-  placebo_mean <- apply(placebo_results, 2, mean)*100
-  placebo_sd <- apply(placebo_results, 2, sd)*100
+  placebo_mean <- apply(placebo_results, 2, mean) * 100
+  placebo_sd <- apply(placebo_results, 2, sd) * 100
   probs <- c(0.90, 0.95, 0.99)
-  placebo_quantiles <- apply(placebo_results, 2, quantile, prob = probs)*100
+  placebo_quantiles <- apply(placebo_results, 2, quantile, prob = probs) * 100
 
   plot_mat <- do.call(rbind, list(placebo_mean, placebo_sd, placebo_quantiles))
   rownames(plot_mat) <- c("mean", "sd", paste("quantile", probs, sep = ""))
   plot_table <- t(plot_mat) %>%
     as.data.frame() %>%
     mutate(bandwidth = bandwidth_seq,
-           real = real$main*100) %>%
+           real = real$main * 100) %>%
     select(bandwidth, real, everything())
 
   # close to mean placebo = 0.05%
@@ -610,16 +610,16 @@ if (show_fig | show_fig6) {
     scale_y_continuous(breaks = seq(0, 1.6, 0.1)) +
     scale_x_continuous(breaks = seq(0, 100000, 10000))
 
-  if (save_fig | save_fig6){
+  if (save_fig | save_fig6) {
     ggsave(paste("fig", fignum, suffix, "OK.jpg", sep = ""),
            path = img_path, fig6_plot,
            width = default_width, height = default_height, units = "in")
-    message(paste("fig", fignum, " is saved in ", img_path, " as fig", 
+    message(paste("fig", fignum, " is saved in ", img_path, " as fig",
                   fignum, suffix, "OK.jpg", sep = ""))
     ggsave(paste("fig", fignum, suffix,"zoomed", suffix, "OK.jpg", sep = ""),
            path = img_path, fig6_plot2,
            width = default_width, height = default_height, units = "in")
-    message(paste("fig", fignum, "_zoomed", " is saved in ", img_path, " as fig", 
+    message(paste("fig", fignum, "_zoomed", " is saved in ", img_path, " as fig",
                   fignum, suffix, "OK.jpg", sep = ""))
   }
 
@@ -629,7 +629,7 @@ if (show_fig | show_fig6) {
 }
 
 ### Figure 6 - B1011 ---------------------------
-fignum <- "6_B1011" 
+fignum <- "6_B1011"
 if (show_fig | show_fig6){
   set.seed(11 + seedplus)
   support <- prep_data(data = Beijing, prep = "support")


### PR DESCRIPTION
In this branch, I considered the procedure described in 3_BMP_GP/notes/newcriterion.pdf.
Essentially, I look at the transport map from the empirical and placebo problems.
I then compute the cost associated with the absolute difference in these transport maps.

This didn't work out so well, so we ultimately went back to the original way of selecting $d$.
Namely, we look at OT_d(P1, P2) where P1 and P2 are drawn from the empirical P_B,2010.
Note, however, that this time, P1 uses n_2010 observations and P2 uses n_2011 observations.

This procedure led to the new Figure 6 (already replaced in main document and in the appendices of the overleaf), an additional figure that plots various statistics of the placebo simulations, and a revised Table 4 (to be manually changed by Guillaume).