### PR TITLE
Argument against criticism of households buying nicer cars as opposed to 2 cars

### DIFF
--- a/data-raw/penalty.r
+++ b/data-raw/penalty.r
@@ -1,0 +1,125 @@
+### Meta ---------------------------
+###
+### Title: penalty.r
+###
+### Description: Carry out the task laid out by 3_BMP_GP/notes/penalty.pdf
+###
+### Author: Omkar A. Katta
+###
+### ---------------------------
+###
+### Notes:
+###
+###
+
+# Preliminaries ---------------------------
+devtools::load_all()
+library(ggplot2)
+source(here::here("data-raw", "prepare_data.R"))
+source(here::here("data-raw", "plotting_functions.R"))
+
+version <- "original"
+grayscale <- FALSE # toggle to TRUE for black-and-white plots
+temp <- ifelse(grayscale, "grayscale", "color")
+
+fontsize <- 20 # change font size of plot, axis, and legend titles
+fontsizeaxis <- 15 # change font size of axis labels
+linetype0 <- "solid" # main line type
+linetype1 <- "dashed" # secondary line type
+linetype2 <- "dotted" # tertiary line type
+linetype3 <- "twodash"
+linetype4 <- "longdash"
+
+img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Nov03", paste(version, temp, sep = "-"), sep = "/")
+suffix <- "_"
+default_width <- 7
+default_height <- 3
+
+load(here::here(".hidden/Beijing_cleaned.RData"))
+Beijing_sample <- Beijing_cleaned
+
+if (version == "original"){
+  Beijing <- Beijing_sample
+  message(paste("Version: ", version, sep = ""))
+} else if (version == "v1"){
+  # filter out Dec 2010
+  Beijing <- Beijing_sample %>%
+    filter(!(year == 2010 & month == 12))
+  message(paste("Version: ", version, sep = ""))
+} else if (version == "v2"){
+  # filter out Dec 2010, Jan 2011, and Feb 2011
+  Beijing <- Beijing_sample %>%
+    filter(!(year == 2010 & month == 12)) %>%
+    filter(!(year == 2011 & month %in% c(1, 2)))
+  message(paste("Version: ", version, sep = ""))
+} else {
+  stop("Specify a valid value for `version`.")
+}
+
+# create support
+support <- prep_data(data = Beijing, prep = "support")
+pre <- prep_data(Beijing, prep = "pmf",
+                 support = support,
+                 lowerdate = "2010-01-01", upperdate = "2011-01-01")
+post <- prep_data(Beijing, prep = "pmf",
+                  support = support,
+                  lowerdate = "2011-01-01", upperdate = "2012-01-01")
+
+# create L1 penalty cost
+Lpcost <- function(min_pre_support, min_post_support, p) {
+  costm <- matrix(NA_real_, nrow = length(min_pre_support), ncol = length(min_post_support))
+  for (i in seq_along(min_pre_support)) {
+      costm[i, ] <- abs(min_pre_support[i] - min_post_support)^p
+  }
+  costm
+}
+
+l1_cost <- Lpcost(support, support, 1)
+
+# initialize values
+bandwidth_seq <- seq(0, 100000, 1000)
+lambda_seq <- c(0, 0.01)
+results <- matrix(NA_real_,
+                  nrow = length(bandwidth_seq), ncol = length(lambda_seq))
+
+# compute data
+pb <- txtProgressBar(0, length(bandwidth_seq))
+for (i in seq_along(bandwidth_seq)) {
+  setTxtProgressBar(pb, i)
+  bw <- bandwidth_seq[i]
+  l0_cost <- build_costmatrix(support = support, bandwidth = bw)
+  for (j in seq_along(lambda_seq)) {
+    lambda <- lambda_seq[j]
+    cost_mat <- l0_cost + lambda * l1_cost
+    OT <- get_OTcost(pre, post, bandwidth = bw, costmat = cost_mat)$prop_bribe * 100
+    results[i, j] <- OT
+  }
+}
+colnames(results) <- paste("lambda", lambda_seq, sep = "")
+
+#~ # sanity check
+#~ real <- diftrans(pre, post, bandwidth_seq = bandwidth_seq, conservative = F)$main * 100
+#~ test <- results[, "lambda0"]
+#~ stopifnot(identical(real, test))
+
+plot_table <- data.frame(results) %>%
+  dplyr::mutate(bandwidth = bandwidth_seq) %>%
+  tidyr::pivot_longer(cols = contains("lambda"))
+
+ggplot(plot_table, aes(x = bandwidth, y = value,
+                       color = name, linetype = name)) +
+  geom_line() +
+  theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5)) +
+  scale_linetype_manual(values = c(linetype0, linetype1),
+                        labels = c("real", "lambda = 0.01"), name = "") +
+  scale_color_manual(values = get_color_palette(2, grayscale),
+                     labels = c("real", "lambda = 0.01"),
+                     name = "") +
+  scale_x_continuous(breaks = seq(0, 100000, 10000), labels = seq(0, 100000, 10000)) +
+  scale_y_continuous(breaks = seq(0, 40, 5)) +
+  xlab("d") +
+  ylab("Transport Cost (%)")
+
+ggsave(paste("fig", suffix, "penalty", suffix, "OK.jpg", sep = ""),
+       path = img_path,
+       width = default_width, height = default_height, units = "in")

--- a/data-raw/penalty.r
+++ b/data-raw/penalty.r
@@ -194,7 +194,7 @@ ggsave(paste("fig", "penalty", "bin", "25000.jpg", sep = "_"),
 
 
 #~ running sum of penalized optimal transport at d* = 25000
-total_mass <- sum(OT_final$total)
+total_mass <- sum(OT_final$total[OT_final$abs_diff > 25000])
 OT_running_sum <- OT_final %>%
   dplyr::arrange(desc(abs_diff)) %>%
   dplyr::mutate(cumulative = cumsum(total)) %>%
@@ -205,8 +205,8 @@ ggplot(OT_running_sum, aes(x = abs_diff, y = percentage)) +
   geom_line() +
   theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5)) +
   xlab("d") +
-  ylab("Mass above d (% of total mass)") +
-  scale_y_continuous(breaks = seq(0, 100, 10)) +
+  ylab("Mass above d (% of total mass > 25000)") +
+  scale_y_continuous(breaks = seq(0, max(OT_running_sum$percentage) + 100, 100)) +
   scale_x_continuous(breaks = seq(0, max(OT_running_sum$abs_diff), 100000))
 
 ggsave(paste("fig", "penalty", "run", "25000.jpg", sep = "_"),

--- a/data-raw/penalty.r
+++ b/data-raw/penalty.r
@@ -30,7 +30,7 @@ linetype2 <- "dotted" # tertiary line type
 linetype3 <- "twodash"
 linetype4 <- "longdash"
 
-img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Nov03", paste(version, temp, sep = "-"), sep = "/")
+img_path <- paste("/Users/omkar_katta/BFI/3_BMP_GP/img/img_misc/Nov04", paste(version, temp, sep = "-"), sep = "/")
 suffix <- "_"
 default_width <- 7
 default_height <- 3
@@ -197,22 +197,25 @@ ggsave(paste("fig", "penalty", "bin", "25000.jpg", sep = "_"),
 total_mass <- sum(OT_final$total[OT_final$abs_diff > 25000])
 OT_running_sum <- OT_final %>%
   dplyr::arrange(desc(abs_diff)) %>%
-  dplyr::mutate(cumulative = cumsum(total)) %>%
+  dplyr::mutate(total_lag = dplyr::lag(total)) %>%
+  tidyr::replace_na(list(total_lag = 0)) %>%
+  dplyr::mutate(cumulative = cumsum(total_lag)) %>%
   dplyr::mutate(percentage = cumulative / total_mass * 100) %>%
-  dplyr::arrange(abs_diff)
+  dplyr::arrange(abs_diff) %>%
+  dplyr::filter(abs_diff >= 25000)
 
 ggplot(OT_running_sum, aes(x = abs_diff, y = percentage)) +
   geom_line() +
   theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5)) +
   xlab("d") +
   ylab("Mass above d (% of total mass > 25000)") +
-  scale_y_continuous(breaks = seq(0, max(OT_running_sum$percentage) + 100, 100)) +
-  scale_x_continuous(breaks = seq(0, max(OT_running_sum$abs_diff), 100000))
+  scale_y_continuous(breaks = seq(0, max(OT_running_sum$percentage), 10)) +
+  scale_x_continuous(breaks = seq(25000, max(OT_running_sum$abs_diff), 100000))
 
 ggsave(paste("fig", "penalty", "run", "25000.jpg", sep = "_"),
        path = img_path, width = default_width, height = default_height, units = "in")
 
 OT_running_sum %>%
-  dplyr::filter(abs_diff %% 10000 < 1000) %>%
+  dplyr::filter(abs_diff %% 5000 < 1000) %>%
   dplyr::select(abs_diff, cumulative, percentage) %>%
   knitr::kable(., format = "latex", booktabs = T, linesep = "", longtable = T, align = 'c')

--- a/data-raw/penalty.r
+++ b/data-raw/penalty.r
@@ -191,3 +191,28 @@ ggplot() +
 
 ggsave(paste("fig", "penalty", "bin", "25000.jpg", sep = "_"),
        path = img_path, width = default_width, height = default_height, units = "in")
+
+
+#~ running sum of penalized optimal transport at d* = 25000
+total_mass <- sum(OT_final$total)
+OT_running_sum <- OT_final %>%
+  dplyr::arrange(desc(abs_diff)) %>%
+  dplyr::mutate(cumulative = cumsum(total)) %>%
+  dplyr::mutate(percentage = cumulative / total_mass * 100) %>%
+  dplyr::arrange(abs_diff)
+
+ggplot(OT_running_sum, aes(x = abs_diff, y = percentage)) +
+  geom_line() +
+  theme_bmp(sizefont = (fontsize - 8), axissizefont = (fontsizeaxis - 5)) +
+  xlab("d") +
+  ylab("Mass above d (% of total mass)") +
+  scale_y_continuous(breaks = seq(0, 100, 10)) +
+  scale_x_continuous(breaks = seq(0, max(OT_running_sum$abs_diff), 100000))
+
+ggsave(paste("fig", "penalty", "run", "25000.jpg", sep = "_"),
+       path = img_path, width = default_width, height = default_height, units = "in")
+
+OT_running_sum %>%
+  dplyr::filter(abs_diff %% 10000 < 1000) %>%
+  dplyr::select(abs_diff, cumulative, percentage) %>%
+  knitr::kable(., format = "latex", booktabs = T, linesep = "", longtable = T, align = 'c')


### PR DESCRIPTION
Households that planned to buy two cars but now buy a more expensive car upon entering the lottery pose a threat to our analysis. 
Namely, these households might be seen as participating in the black market when in actuality, they are not.
Our argument for why such households are not a concern for us is that the nicer car they buy must be above 100K because our analysis was robust for bandwidths as large as 100K.
This argument was flawed for two reasons:

- For bandwidths as large as 100K, the actual before-and-after estimate was very different from the one we put forth at d = 25K (originally, we said d=10K).
- This argument depends on the solution to the optimal transport problem but the solution need not be unique.

To overcome these challenges, we considered a less favorable solution, i.e., a solution to a penalized optimal transport problem that is unique.
For the bandwidth that we put forth in the original problem (d*=25K), we looked at the unique solution to the penalized program.
We asked: how much of the mass that was traded above d*=25K is made of mass that was traded above d, where d is some number greater than 25K?
If we show that most of the mass above 25K is due to trades that occurred when the absolute difference in car prices is really large, then we can say that the households that buy a nicer car must have bought a car that is at least this absolute difference larger than the original car they planned to buy. 
For us, roughly 99% of the mass traded above 25K is for transfers where the absolute difference in car prices is greater than 100K RMB. Thus, households that buy a nicer car must have bought cars that are greater than 100K RMB the price of the car they would have bought in the absence of the lottery in order for them to pose a threat to our analysis. This seems very unlikely, so our analysis stands.
